### PR TITLE
Scrollable in pageslide block?

### DIFF
--- a/src/angular-pageslide-directive.js
+++ b/src/angular-pageslide-directive.js
@@ -62,6 +62,7 @@ pageslideDirective.directive('pageslide', [
                 slider.style.width = 0;
                 slider.style.height = 0;
                 slider.style.transitionProperty = 'width, height';
+                slider.style.overflow = 'auto';
 
                 switch (param.side){
                     case 'right':


### PR DESCRIPTION
I'd like to be able to add a tall div to a short page.
This seems to do the trick.

I'm just making this edit within Github so I've not been able to Grunt the dist folder or do too many tests I'm afraid.

This is more of a "this would be nice" idea submission.

Hope you agree.