### PR TITLE
Fix pageslide documentation to match example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,11 +31,11 @@ also you need an inner ```<div>``` to wrap your content in
 ```
 <div ... ng-controller="yourCtrl">
     ...
-    <pageslide ps-open="checked">
+    <div pageslide ps-open="checked">
         <div>            
             <p>some random content...</p>
         </div>
-    </pageslide>
+    </div>
     ...
 </div>
 


### PR DESCRIPTION
Using pageslide as an element didn't work for me. Using it as an attribute did. This is the way it happens in example.html, so let's start people off on familiar footing.