### PR TITLE
Let the slider div render in a parent div of choosing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,7 @@ ps-custom-top (optional) = custom CSS for panel top (only applicable in 'right',
 ps-custom-bottom (optional) = custom CSS for panel bottom (only applicable in 'right', 'left' or 'bottom' panels)
 ps-custom-left (optional) = custom CSS for panel left (only applicable in 'left', 'top' or 'bottom' panels)
 ps-custom-right (optional) = custom CSS for panel right (only applicable in 'right', 'top' or 'bottom' panels)
+ps-container (optional) = custom CSS ID selector to which the slider div appends (e.g: <div id='myDiv'/> -> ps-container="myDiv") 
 ```
 
 * these options make assumptions about the layout, will set body positioning to absolute

--- a/src/angular-pageslide-directive.js
+++ b/src/angular-pageslide-directive.js
@@ -1,239 +1,239 @@
 angular.module("pageslide-directive", [])
 
 .directive('pageslide', [
-  function() {
-    var defaults = {};
+    function () {
+        var defaults = {};
 
-    /* Return directive definition object */
+        /* Return directive definition object */
 
-    return {
-      restrict: "EAC",
-      transclude: false,
-      scope: {
-        psOpen: "=?",
-        psAutoClose: "=?",
-        psSide: "@",
-        psSpeed: "@",
-        psClass: "@",
-        psSize: "@",
-        psSqueeze: "@",
-        psCloak: "@",
-        psPush: "@",
-        psContainer: "@"
-      },
-      //template: '<div class="pageslide-content" ng-transclude></div>',
-      link: function($scope, el, attrs) {
-        /* Inspect */
-        //console.log($scope);
-        //console.log(el);
-        //console.log(attrs);
+        return {
+            restrict: "EAC",
+            transclude: false,
+            scope: {
+                psOpen: "=?",
+                psAutoClose: "=?",
+                psSide: "@",
+                psSpeed: "@",
+                psClass: "@",
+                psSize: "@",
+                psSqueeze: "@",
+                psCloak: "@",
+                psPush: "@",
+                psContainer: "@"
+            },
+            //template: '<div class="pageslide-content" ng-transclude></div>',
+            link: function ($scope, el, attrs) {
+                /* Inspect */
+                //console.log($scope);
+                //console.log(el);
+                //console.log(attrs);
 
-        /* Parameters */
-        var param = {};
+                /* Parameters */
+                var param = {};
 
-        param.side = $scope.psSide || 'right';
-        param.speed = $scope.psSpeed || '0.5';
-        param.size = $scope.psSize || '300px';
-        param.zindex = 1000; // Override with custom CSS
-        param.className = $scope.psClass || 'ng-pageslide';
-        param.cloak = $scope.psCloak && $scope.psCloak.toLowerCase() == 'false' ? false : true;
-        param.squeeze = Boolean($scope.psSqueeze) || false;
-        param.push = Boolean($scope.psPush) || false;
-        param.container = $scope.psContainer || false;
+                param.side = $scope.psSide || 'right';
+                param.speed = $scope.psSpeed || '0.5';
+                param.size = $scope.psSize || '300px';
+                param.zindex = 1000; // Override with custom CSS
+                param.className = $scope.psClass || 'ng-pageslide';
+                param.cloak = $scope.psCloak && $scope.psCloak.toLowerCase() == 'false' ? false : true;
+                param.squeeze = Boolean($scope.psSqueeze) || false;
+                param.push = Boolean($scope.psPush) || false;
+                param.container = $scope.psContainer || false;
 
-        // Apply Class
-        el.addClass(param.className);
+                // Apply Class
+                el.addClass(param.className);
 
-        /* DOM manipulation */
-        var content = null;
-        var slider = null;
-        var body = param.container !== false ? document.getElementById(param.container) : document.body;
+                /* DOM manipulation */
+                var content = null;
+                var slider = null;
+                var body = param.container !== false ? document.getElementById(param.container) : document.body;
 
-        slider = el[0];
+                slider = el[0];
 
-        // Check for div tag
-        if (slider.tagName.toLowerCase() !== 'div' &&
-          slider.tagName.toLowerCase() !== 'pageslide')
-          throw new Error('Pageslide can only be applied to <div> or <pageslide> elements');
+                // Check for div tag
+                if (slider.tagName.toLowerCase() !== 'div' &&
+                    slider.tagName.toLowerCase() !== 'pageslide')
+                    throw new Error('Pageslide can only be applied to <div> or <pageslide> elements');
 
-        // Check for content
-        if (slider.children.length === 0)
-          throw new Error('You have to content inside the <pageslide>');
+                // Check for content
+                if (slider.children.length === 0)
+                    throw new Error('You have to content inside the <pageslide>');
 
-        content = angular.element(slider.children);
+                content = angular.element(slider.children);
 
-        /* Append */
-        body.appendChild(slider);
-
-
-        /* Style setup */
-        slider.style.zIndex = param.zindex;
-        slider.style.position = param.container !== false ? 'absolute' : 'fixed';
-        slider.style.width = 0;
-        slider.style.height = 0;
-        slider.style.overflow = 'hidden';
-        slider.style.transitionDuration = param.speed + 's';
-        slider.style.webkitTransitionDuration = param.speed + 's';
-        slider.style.transitionProperty = 'width, height';
-        if (param.squeeze) {
-          body.style.position = 'absolute';
-          body.style.transitionDuration = param.speed + 's';
-          body.style.webkitTransitionDuration = param.speed + 's';
-          body.style.transitionProperty = 'top, bottom, left, right';
-        }
-
-        switch (param.side) {
-          case 'right':
-            slider.style.height = attrs.psCustomHeight || '100%';
-            slider.style.top = attrs.psCustomTop || '0px';
-            slider.style.bottom = attrs.psCustomBottom || '0px';
-            slider.style.right = attrs.psCustomRight || '0px';
-            break;
-          case 'left':
-            slider.style.height = attrs.psCustomHeight || '100%';
-            slider.style.top = attrs.psCustomTop || '0px';
-            slider.style.bottom = attrs.psCustomBottom || '0px';
-            slider.style.left = attrs.psCustomLeft || '0px';
-            break;
-          case 'top':
-            slider.style.width = attrs.psCustomWidth || '100%';
-            slider.style.left = attrs.psCustomLeft || '0px';
-            slider.style.top = attrs.psCustomTop || '0px';
-            slider.style.right = attrs.psCustomRight || '0px';
-            break;
-          case 'bottom':
-            slider.style.width = attrs.psCustomWidth || '100%';
-            slider.style.bottom = attrs.psCustomBottom || '0px';
-            slider.style.left = attrs.psCustomLeft || '0px';
-            slider.style.right = attrs.psCustomRight || '0px';
-            break;
-        }
+                /* Append */
+                body.appendChild(slider);
 
 
-        /* Closed */
-        function psClose(slider, param) {
-          if (slider && slider.style.width !== 0 && slider.style.width !== 0) {
-            if (param.cloak) content.css('display', 'none');
-            switch (param.side) {
-              case 'right':
-                slider.style.width = '0px';
-                if (param.squeeze) body.style.right = '0px';
-                if (param.push) {
-                  body.style.right = '0px';
-                  body.style.left = '0px';
+                /* Style setup */
+                slider.style.zIndex = param.zindex;
+                slider.style.position = param.container !== false ? 'absolute' : 'fixed';
+                slider.style.width = 0;
+                slider.style.height = 0;
+                slider.style.overflow = 'hidden';
+                slider.style.transitionDuration = param.speed + 's';
+                slider.style.webkitTransitionDuration = param.speed + 's';
+                slider.style.transitionProperty = 'width, height';
+                if (param.squeeze) {
+                    body.style.position = 'absolute';
+                    body.style.transitionDuration = param.speed + 's';
+                    body.style.webkitTransitionDuration = param.speed + 's';
+                    body.style.transitionProperty = 'top, bottom, left, right';
                 }
-                break;
-              case 'left':
-                slider.style.width = '0px';
-                if (param.squeeze) body.style.left = '0px';
-                if (param.push) {
-                  body.style.left = '0px';
-                  body.style.right = '0px';
+
+                switch (param.side) {
+                    case 'right':
+                        slider.style.height = attrs.psCustomHeight || '100%';
+                        slider.style.top = attrs.psCustomTop || '0px';
+                        slider.style.bottom = attrs.psCustomBottom || '0px';
+                        slider.style.right = attrs.psCustomRight || '0px';
+                        break;
+                    case 'left':
+                        slider.style.height = attrs.psCustomHeight || '100%';
+                        slider.style.top = attrs.psCustomTop || '0px';
+                        slider.style.bottom = attrs.psCustomBottom || '0px';
+                        slider.style.left = attrs.psCustomLeft || '0px';
+                        break;
+                    case 'top':
+                        slider.style.width = attrs.psCustomWidth || '100%';
+                        slider.style.left = attrs.psCustomLeft || '0px';
+                        slider.style.top = attrs.psCustomTop || '0px';
+                        slider.style.right = attrs.psCustomRight || '0px';
+                        break;
+                    case 'bottom':
+                        slider.style.width = attrs.psCustomWidth || '100%';
+                        slider.style.bottom = attrs.psCustomBottom || '0px';
+                        slider.style.left = attrs.psCustomLeft || '0px';
+                        slider.style.right = attrs.psCustomRight || '0px';
+                        break;
                 }
-                break;
-              case 'top':
-                slider.style.height = '0px';
-                if (param.squeeze) body.style.top = '0px';
-                if (param.push) {
-                  body.style.top = '0px';
-                  body.style.bottom = '0px';
+
+
+                /* Closed */
+                function psClose(slider, param) {
+                    if (slider && slider.style.width !== 0 && slider.style.width !== 0) {
+                        if (param.cloak) content.css('display', 'none');
+                        switch (param.side) {
+                            case 'right':
+                                slider.style.width = '0px';
+                                if (param.squeeze) body.style.right = '0px';
+                                if (param.push) {
+                                    body.style.right = '0px';
+                                    body.style.left = '0px';
+                                }
+                                break;
+                            case 'left':
+                                slider.style.width = '0px';
+                                if (param.squeeze) body.style.left = '0px';
+                                if (param.push) {
+                                    body.style.left = '0px';
+                                    body.style.right = '0px';
+                                }
+                                break;
+                            case 'top':
+                                slider.style.height = '0px';
+                                if (param.squeeze) body.style.top = '0px';
+                                if (param.push) {
+                                    body.style.top = '0px';
+                                    body.style.bottom = '0px';
+                                }
+                                break;
+                            case 'bottom':
+                                slider.style.height = '0px';
+                                if (param.squeeze) body.style.bottom = '0px';
+                                if (param.push) {
+                                    body.style.bottom = '0px';
+                                    body.style.top = '0px';
+                                }
+                                break;
+                        }
+                    }
+                    $scope.psOpen = false;
                 }
-                break;
-              case 'bottom':
-                slider.style.height = '0px';
-                if (param.squeeze) body.style.bottom = '0px';
-                if (param.push) {
-                  body.style.bottom = '0px';
-                  body.style.top = '0px';
+
+                /* Open */
+                function psOpen(slider, param) {
+                    if (slider.style.width !== 0 && slider.style.width !== 0) {
+                        switch (param.side) {
+                            case 'right':
+                                slider.style.width = param.size;
+                                if (param.squeeze) body.style.right = param.size;
+                                if (param.push) {
+                                    body.style.right = param.size;
+                                    body.style.left = "-" + param.size;
+                                }
+                                break;
+                            case 'left':
+                                slider.style.width = param.size;
+                                if (param.squeeze) body.style.left = param.size;
+                                if (param.push) {
+                                    body.style.left = param.size;
+                                    body.style.right = "-" + param.size;
+                                }
+                                break;
+                            case 'top':
+                                slider.style.height = param.size;
+                                if (param.squeeze) body.style.top = param.size;
+                                if (param.push) {
+                                    body.style.top = param.size;
+                                    body.style.bottom = "-" + param.size;
+                                }
+                                break;
+                            case 'bottom':
+                                slider.style.height = param.size;
+                                if (param.squeeze) body.style.bottom = param.size;
+                                if (param.push) {
+                                    body.style.bottom = param.size;
+                                    body.style.top = "-" + param.size;
+                                }
+                                break;
+                        }
+                        setTimeout(function () {
+                            if (param.cloak) content.css('display', 'block');
+                        }, (param.speed * 1000));
+
+                    }
                 }
-                break;
+
+                function isFunction(functionToCheck) {
+                    var getType = {};
+                    return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]';
+                }
+
+                /*
+                 * Watchers
+                 * */
+
+                $scope.$watch("psOpen", function (value) {
+                    if (!!value) {
+                        // Open
+                        psOpen(slider, param);
+                    } else {
+                        // Close
+                        psClose(slider, param);
+                    }
+                });
+
+
+                /*
+                 * Events
+                 * */
+
+                $scope.$on('$destroy', function () {
+                    body.removeChild(slider);
+                });
+
+                if ($scope.psAutoClose) {
+                    $scope.$on("$locationChangeStart", function () {
+                        psClose(slider, param);
+                    });
+                    $scope.$on("$stateChangeStart", function () {
+                        psClose(slider, param);
+                    });
+
+                }
             }
-          }
-          $scope.psOpen = false;
-        }
-
-        /* Open */
-        function psOpen(slider, param) {
-          if (slider.style.width !== 0 && slider.style.width !== 0) {
-            switch (param.side) {
-              case 'right':
-                slider.style.width = param.size;
-                if (param.squeeze) body.style.right = param.size;
-                if (param.push) {
-                  body.style.right = param.size;
-                  body.style.left = "-" + param.size;
-                }
-                break;
-              case 'left':
-                slider.style.width = param.size;
-                if (param.squeeze) body.style.left = param.size;
-                if (param.push) {
-                  body.style.left = param.size;
-                  body.style.right = "-" + param.size;
-                }
-                break;
-              case 'top':
-                slider.style.height = param.size;
-                if (param.squeeze) body.style.top = param.size;
-                if (param.push) {
-                  body.style.top = param.size;
-                  body.style.bottom = "-" + param.size;
-                }
-                break;
-              case 'bottom':
-                slider.style.height = param.size;
-                if (param.squeeze) body.style.bottom = param.size;
-                if (param.push) {
-                  body.style.bottom = param.size;
-                  body.style.top = "-" + param.size;
-                }
-                break;
-            }
-            setTimeout(function() {
-              if (param.cloak) content.css('display', 'block');
-            }, (param.speed * 1000));
-
-          }
-        }
-
-        function isFunction(functionToCheck) {
-          var getType = {};
-          return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]';
-        }
-
-        /*
-         * Watchers
-         * */
-
-        $scope.$watch("psOpen", function(value) {
-          if (!!value) {
-            // Open
-            psOpen(slider, param);
-          } else {
-            // Close
-            psClose(slider, param);
-          }
-        });
-
-
-        /*
-         * Events
-         * */
-
-        $scope.$on('$destroy', function() {
-          document.body.removeChild(slider);
-        });
-
-        if ($scope.psAutoClose) {
-          $scope.$on("$locationChangeStart", function() {
-            psClose(slider, param);
-          });
-          $scope.$on("$stateChangeStart", function() {
-            psClose(slider, param);
-          });
-
-        }
-      }
-    };
-  }
+        };
+    }
 ]);

--- a/src/angular-pageslide-directive.js
+++ b/src/angular-pageslide-directive.js
@@ -1,237 +1,239 @@
 angular.module("pageslide-directive", [])
 
 .directive('pageslide', [
-    function () {
-        var defaults = {};
+  function() {
+    var defaults = {};
 
-        /* Return directive definition object */
+    /* Return directive definition object */
 
-        return {
-            restrict: "EAC",
-            transclude: false,
-            scope: {
-                psOpen: "=?",
-                psAutoClose: "=?",
-                psSide: "@",
-                psSpeed: "@",
-                psClass: "@",
-                psSize: "@",
-                psSqueeze: "@",
-                psCloak: "@",
-                psPush: "@"
-            },
-            //template: '<div class="pageslide-content" ng-transclude></div>',
-            link: function ($scope, el, attrs) {
-                /* Inspect */
-                //console.log($scope);
-                //console.log(el);
-                //console.log(attrs);
+    return {
+      restrict: "EAC",
+      transclude: false,
+      scope: {
+        psOpen: "=?",
+        psAutoClose: "=?",
+        psSide: "@",
+        psSpeed: "@",
+        psClass: "@",
+        psSize: "@",
+        psSqueeze: "@",
+        psCloak: "@",
+        psPush: "@",
+        psContainer: "@"
+      },
+      //template: '<div class="pageslide-content" ng-transclude></div>',
+      link: function($scope, el, attrs) {
+        /* Inspect */
+        //console.log($scope);
+        //console.log(el);
+        //console.log(attrs);
 
-                /* Parameters */
-                var param = {};
+        /* Parameters */
+        var param = {};
 
-                param.side = $scope.psSide || 'right';
-                param.speed = $scope.psSpeed || '0.5';
-                param.size = $scope.psSize || '300px';
-                param.zindex = 1000; // Override with custom CSS
-                param.className = $scope.psClass || 'ng-pageslide';
-                param.cloak = $scope.psCloak && $scope.psCloak.toLowerCase() == 'false' ? false : true;
-                param.squeeze = Boolean($scope.psSqueeze) || false;
-                param.push = Boolean($scope.psPush) || false;
-                
-                // Apply Class
-                el.addClass(param.className);
+        param.side = $scope.psSide || 'right';
+        param.speed = $scope.psSpeed || '0.5';
+        param.size = $scope.psSize || '300px';
+        param.zindex = 1000; // Override with custom CSS
+        param.className = $scope.psClass || 'ng-pageslide';
+        param.cloak = $scope.psCloak && $scope.psCloak.toLowerCase() == 'false' ? false : true;
+        param.squeeze = Boolean($scope.psSqueeze) || false;
+        param.push = Boolean($scope.psPush) || false;
+        param.container = $scope.psContainer || false;
 
-                /* DOM manipulation */
-                var content = null;
-                var slider = null;
-                var body = document.body;
+        // Apply Class
+        el.addClass(param.className);
 
-                slider = el[0];
+        /* DOM manipulation */
+        var content = null;
+        var slider = null;
+        var body = param.container !== false ? document.getElementById(param.container) : document.body;
 
-                // Check for div tag
-                if (slider.tagName.toLowerCase() !== 'div' &&
-                    slider.tagName.toLowerCase() !== 'pageslide')
-                    throw new Error('Pageslide can only be applied to <div> or <pageslide> elements');
+        slider = el[0];
 
-                // Check for content
-                if (slider.children.length === 0) 
-                    throw new Error('You have to content inside the <pageslide>');
-                
-                content = angular.element(slider.children);
+        // Check for div tag
+        if (slider.tagName.toLowerCase() !== 'div' &&
+          slider.tagName.toLowerCase() !== 'pageslide')
+          throw new Error('Pageslide can only be applied to <div> or <pageslide> elements');
 
-                /* Append */
-                body.appendChild(slider);
+        // Check for content
+        if (slider.children.length === 0)
+          throw new Error('You have to content inside the <pageslide>');
 
-                /* Style setup */
-                slider.style.zIndex = param.zindex;
-                slider.style.position = 'fixed'; // this is fixed because has to cover full page
-                slider.style.width = 0;
-                slider.style.height = 0;
-                slider.style.overflow = 'hidden';
-                slider.style.transitionDuration = param.speed + 's';
-                slider.style.webkitTransitionDuration = param.speed + 's';
-                slider.style.transitionProperty = 'width, height';
-                if (param.squeeze) {
-                    body.style.position = 'absolute';
-                    body.style.transitionDuration = param.speed + 's';
-                    body.style.webkitTransitionDuration = param.speed + 's';
-                    body.style.transitionProperty = 'top, bottom, left, right';
+        content = angular.element(slider.children);
+
+        /* Append */
+        body.appendChild(slider);
+
+
+        /* Style setup */
+        slider.style.zIndex = param.zindex;
+        slider.style.position = param.container !== false ? 'absolute' : 'fixed';
+        slider.style.width = 0;
+        slider.style.height = 0;
+        slider.style.overflow = 'hidden';
+        slider.style.transitionDuration = param.speed + 's';
+        slider.style.webkitTransitionDuration = param.speed + 's';
+        slider.style.transitionProperty = 'width, height';
+        if (param.squeeze) {
+          body.style.position = 'absolute';
+          body.style.transitionDuration = param.speed + 's';
+          body.style.webkitTransitionDuration = param.speed + 's';
+          body.style.transitionProperty = 'top, bottom, left, right';
+        }
+
+        switch (param.side) {
+          case 'right':
+            slider.style.height = attrs.psCustomHeight || '100%';
+            slider.style.top = attrs.psCustomTop || '0px';
+            slider.style.bottom = attrs.psCustomBottom || '0px';
+            slider.style.right = attrs.psCustomRight || '0px';
+            break;
+          case 'left':
+            slider.style.height = attrs.psCustomHeight || '100%';
+            slider.style.top = attrs.psCustomTop || '0px';
+            slider.style.bottom = attrs.psCustomBottom || '0px';
+            slider.style.left = attrs.psCustomLeft || '0px';
+            break;
+          case 'top':
+            slider.style.width = attrs.psCustomWidth || '100%';
+            slider.style.left = attrs.psCustomLeft || '0px';
+            slider.style.top = attrs.psCustomTop || '0px';
+            slider.style.right = attrs.psCustomRight || '0px';
+            break;
+          case 'bottom':
+            slider.style.width = attrs.psCustomWidth || '100%';
+            slider.style.bottom = attrs.psCustomBottom || '0px';
+            slider.style.left = attrs.psCustomLeft || '0px';
+            slider.style.right = attrs.psCustomRight || '0px';
+            break;
+        }
+
+
+        /* Closed */
+        function psClose(slider, param) {
+          if (slider && slider.style.width !== 0 && slider.style.width !== 0) {
+            if (param.cloak) content.css('display', 'none');
+            switch (param.side) {
+              case 'right':
+                slider.style.width = '0px';
+                if (param.squeeze) body.style.right = '0px';
+                if (param.push) {
+                  body.style.right = '0px';
+                  body.style.left = '0px';
                 }
-
-                switch (param.side){
-                    case 'right':
-                        slider.style.height = attrs.psCustomHeight || '100%'; 
-                        slider.style.top = attrs.psCustomTop ||  '0px';
-                        slider.style.bottom = attrs.psCustomBottom ||  '0px';
-                        slider.style.right = attrs.psCustomRight ||  '0px';
-                        break;
-                    case 'left':
-                        slider.style.height = attrs.psCustomHeight || '100%';   
-                        slider.style.top = attrs.psCustomTop || '0px';
-                        slider.style.bottom = attrs.psCustomBottom || '0px';
-                        slider.style.left = attrs.psCustomLeft || '0px';
-                        break;
-                    case 'top':
-                        slider.style.width = attrs.psCustomWidth || '100%';   
-                        slider.style.left = attrs.psCustomLeft || '0px';
-                        slider.style.top = attrs.psCustomTop || '0px';
-                        slider.style.right = attrs.psCustomRight || '0px';
-                        break;
-                    case 'bottom':
-                        slider.style.width = attrs.psCustomWidth || '100%'; 
-                        slider.style.bottom = attrs.psCustomBottom || '0px';
-                        slider.style.left = attrs.psCustomLeft || '0px';
-                        slider.style.right = attrs.psCustomRight || '0px';
-                        break;
+                break;
+              case 'left':
+                slider.style.width = '0px';
+                if (param.squeeze) body.style.left = '0px';
+                if (param.push) {
+                  body.style.left = '0px';
+                  body.style.right = '0px';
                 }
-
-
-                /* Closed */
-                function psClose(slider,param){
-                    if (slider && slider.style.width !== 0 && slider.style.width !== 0){
-                        if (param.cloak) content.css('display', 'none');
-                        switch (param.side){
-                            case 'right':
-                                slider.style.width = '0px'; 
-                                if (param.squeeze) body.style.right = '0px'; 
-                                if (param.push) {
-                                    body.style.right = '0px'; 
-                                    body.style.left = '0px'; 
-                                }
-                                break;
-                            case 'left':
-                                slider.style.width = '0px';
-                                if (param.squeeze) body.style.left = '0px'; 
-                                if (param.push) {
-                                    body.style.left = '0px'; 
-                                    body.style.right = '0px'; 
-                                }
-                                break;
-                            case 'top':
-                                slider.style.height = '0px'; 
-                                if (param.squeeze) body.style.top = '0px'; 
-                                if (param.push) {
-                                    body.style.top = '0px'; 
-                                    body.style.bottom = '0px'; 
-                                }
-                                break;
-                            case 'bottom':
-                                slider.style.height = '0px'; 
-                                if (param.squeeze) body.style.bottom = '0px'; 
-                                if (param.push) {
-                                    body.style.bottom = '0px'; 
-                                    body.style.top = '0px'; 
-                                }
-                                break;
-                        }
-                    }
-                    $scope.psOpen = false;
+                break;
+              case 'top':
+                slider.style.height = '0px';
+                if (param.squeeze) body.style.top = '0px';
+                if (param.push) {
+                  body.style.top = '0px';
+                  body.style.bottom = '0px';
                 }
-
-                /* Open */
-                function psOpen(slider, param){
-                    if (slider.style.width !== 0 && slider.style.width !== 0){
-                        switch (param.side){
-                            case 'right':
-                                slider.style.width = param.size; 
-                                if (param.squeeze) body.style.right = param.size; 
-                                if (param.push) {
-                                    body.style.right = param.size; 
-                                    body.style.left = "-" + param.size; 
-                                }
-                                break;
-                            case 'left':
-                                slider.style.width = param.size; 
-                                if (param.squeeze) body.style.left = param.size; 
-                                if (param.push) {
-                                    body.style.left = param.size; 
-                                    body.style.right = "-" + param.size; 
-                                }
-                                break;
-                            case 'top':
-                                slider.style.height = param.size; 
-                                if (param.squeeze) body.style.top = param.size; 
-                                if (param.push) {
-                                    body.style.top = param.size; 
-                                    body.style.bottom = "-" + param.size; 
-                                }
-                                break;
-                            case 'bottom':
-                                slider.style.height = param.size; 
-                                if (param.squeeze) body.style.bottom = param.size; 
-                                if (param.push) {
-                                    body.style.bottom = param.size; 
-                                    body.style.top = "-" + param.size; 
-                                }
-                                break;
-                        }
-                        setTimeout(function(){
-                            if (param.cloak) content.css('display', 'block');
-                        },(param.speed * 1000));
-
-                    }
+                break;
+              case 'bottom':
+                slider.style.height = '0px';
+                if (param.squeeze) body.style.bottom = '0px';
+                if (param.push) {
+                  body.style.bottom = '0px';
+                  body.style.top = '0px';
                 }
-
-                function isFunction(functionToCheck){
-                    var getType = {};
-                    return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]';
-                }
-
-                /*
-                * Watchers
-                * */
-
-                $scope.$watch("psOpen", function (value){
-                    if (!!value) {
-                        // Open
-                        psOpen(slider,param);
-                    } else {
-                        // Close
-                        psClose(slider,param);
-                    }
-                });
-
-
-                /*
-                * Events
-                * */
-
-                $scope.$on('$destroy', function() {
-                    document.body.removeChild(slider);
-                });
-
-                if($scope.psAutoClose){
-                    $scope.$on("$locationChangeStart", function(){
-                        psClose(slider, param);
-                    });
-                    $scope.$on("$stateChangeStart", function(){
-                        psClose(slider, param);
-                    });
-
-                }
+                break;
             }
-        };
-    }
-]);
+          }
+          $scope.psOpen = false;
+        }
 
+        /* Open */
+        function psOpen(slider, param) {
+          if (slider.style.width !== 0 && slider.style.width !== 0) {
+            switch (param.side) {
+              case 'right':
+                slider.style.width = param.size;
+                if (param.squeeze) body.style.right = param.size;
+                if (param.push) {
+                  body.style.right = param.size;
+                  body.style.left = "-" + param.size;
+                }
+                break;
+              case 'left':
+                slider.style.width = param.size;
+                if (param.squeeze) body.style.left = param.size;
+                if (param.push) {
+                  body.style.left = param.size;
+                  body.style.right = "-" + param.size;
+                }
+                break;
+              case 'top':
+                slider.style.height = param.size;
+                if (param.squeeze) body.style.top = param.size;
+                if (param.push) {
+                  body.style.top = param.size;
+                  body.style.bottom = "-" + param.size;
+                }
+                break;
+              case 'bottom':
+                slider.style.height = param.size;
+                if (param.squeeze) body.style.bottom = param.size;
+                if (param.push) {
+                  body.style.bottom = param.size;
+                  body.style.top = "-" + param.size;
+                }
+                break;
+            }
+            setTimeout(function() {
+              if (param.cloak) content.css('display', 'block');
+            }, (param.speed * 1000));
+
+          }
+        }
+
+        function isFunction(functionToCheck) {
+          var getType = {};
+          return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]';
+        }
+
+        /*
+         * Watchers
+         * */
+
+        $scope.$watch("psOpen", function(value) {
+          if (!!value) {
+            // Open
+            psOpen(slider, param);
+          } else {
+            // Close
+            psClose(slider, param);
+          }
+        });
+
+
+        /*
+         * Events
+         * */
+
+        $scope.$on('$destroy', function() {
+          document.body.removeChild(slider);
+        });
+
+        if ($scope.psAutoClose) {
+          $scope.$on("$locationChangeStart", function() {
+            psClose(slider, param);
+          });
+          $scope.$on("$stateChangeStart", function() {
+            psClose(slider, param);
+          });
+
+        }
+      }
+    };
+  }
+]);


### PR DESCRIPTION
This PR contains changes that fixes: #42

By adding ps-container attribute, the slider div get's rendered inside the parent div of choosing. 

Note that the parent div must contain: postion: relative for this to work. 

For now this only supports id's, should be able to expand it to support both classes and id's.  