### PR TITLE
event listener to close sidebar with 'esc' key

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -8,7 +8,7 @@
 
         <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
         <script src="../src/angular-pageslide-directive.js"></script>
-        <link rel="stylesheet" type="text/css" href="http://cdn.jsdelivr.net/foundation/5.0.0/css/foundation.min.css"> 
+        <link rel="stylesheet" type="text/css" href="http://cdn.jsdelivr.net/foundation/5.0.0/css/foundation.min.css">
         <title>AngularJS Pageslide directive demo</title>
         <style>
             /* Needed for hiding crollbars when pushing */
@@ -63,7 +63,7 @@
                 An <a href="http://angularjs.org/">AngularJS</a> directive which slides another panel over your browser to reveal an additional interaction pane.<br/>
                 It does all the css manipulation needed to position your content off canvas with html attibutes and it does not depend on jQuery
             </p>
-            
+
             <div ng-controller="pageslideCtrl">
                 <a class="large button" href="" ng-click="toggle()">Open Demo</a>
                 <div pageslide ps-open="checked">
@@ -74,7 +74,7 @@
                     </div>
                 </div>
             </div>
-            
+
             <h3>Different speeds</h3>
             <div ng-controller="pageslideCtrl">
                 <a class="tiny button" href="" ng-click="toggle()">Slowmo</a>
@@ -86,7 +86,7 @@
                     </div>
                 </div>
             </div>
-            
+
             <div ng-controller="pageslideCtrl">
                 <a class="tiny button" href="" ng-click="toggle()">Fastbro</a>
                 <div pageslide ps-open="checked" ps-speed="0.25">
@@ -97,7 +97,7 @@
                     </div>
                 </div>
             </div>
-            
+
             <h3>Different directions</h3>
             <div ng-controller="pageslideCtrl">
                 <a class="tiny button" href="" ng-click="toggle()">Up up and above</a>
@@ -109,7 +109,7 @@
                     </div>
                 </div>
             </div>
-            
+
             <div ng-controller="pageslideCtrl">
                 <a class="tiny button" href="" ng-click="toggle()">Go west</a>
                 <div pageslide ps-open="checked" ps-side="left">
@@ -120,7 +120,7 @@
                     </div>
                 </div>
             </div>
-            
+
             <h3>Push content</h3>
             <div ng-controller="pageslideCtrl">
                 <a class="tiny button" href="" ng-click="toggle()">Open Sidebar</a>
@@ -144,7 +144,19 @@
                     </div>
                 </div>
             </div>
-            
+
+            <h3>Escape key to close</h3>
+            <div ng-controller="pageslideCtrl">
+                <a class="tiny button" href="" ng-click="toggle()">Open sidebar</a>
+                <div pageslide ps-open="checked" ps-key-listener="true">
+                    <div style="padding:20px" id="demo-right">
+                        <h2>Hello Pageslide</h2>
+                        <p>hit the escape key to close the sidebar</p>
+                        <a ng-click="toggle()" class="button" >Close</a>
+                    </div>
+                </div>
+            </div>
+
             <br/>
 
             <div ng-controller="pageslideCtrl">
@@ -160,36 +172,36 @@
 
             <div ng-controller="pageslideCtrl">
                 <h3>As an attribute</h3>
-                <p>Check to open: <input type="checkbox" ng-model="checked" ></p> 
+                <p>Check to open: <input type="checkbox" ng-model="checked" ></p>
                 <div pageslide ps-open="checked" >
                 <div style="padding:20px">
                     <h2>Cool Pageslide</h2>
                     <p>Put here whatever you want</p>
                 </div>
-                </div> 
+                </div>
             </div>
-            
+
             <div ng-controller="pageslideCtrl">
                 <h3>As an element</h3>
-                <p>Check to open: <input type="checkbox" ng-model="checked" ></p> 
+                <p>Check to open: <input type="checkbox" ng-model="checked" ></p>
                 <pageslide ps-open="checked" >
                 <div style="padding:20px">
                     <h2>Yes Pageslide</h2>
                     <p>Put here whatever you want</p>
                 </div>
-                </pageslide> 
+                </pageslide>
             </div>
-            
+
             <!--
             <div ng-controller="pageslideCtrl">
                 <h3>With custom styles</h3>
-                <p>Check to open: <input type="checkbox" ng-model="checked" ></p> 
+                <p>Check to open: <input type="checkbox" ng-model="checked" ></p>
                 <pageslide ps-class="panel" ps-open="checked" >
                 <div>
                     <h2>Rad Pageslide</h2>
                     <p>Put here whatever you want</p>
                 </div>
-                </pageslide> 
+                </pageslide>
             </div>
             -->
 

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,7 @@ ps-class (optional) = The class for the pageslide (default: "ng-pageslide")
 ps-auto-close (optional) = true if you want the panel to close on location change
 ps-size (optional) = desired height/width of panel (defaults to 300px)
 ps-cloak (optional) = hides the content until the panel is open (defaults to true)
+ps-key-listener (optional) = close the sidebar with the ESC key (defaults to false)
 
 ps-push (optional) = push the main body to show the panel (defaults to false)*
 ps-squeeze (optional) = squeeze body to fit the panel (defaults to false)*

--- a/src/angular-pageslide-directive.js
+++ b/src/angular-pageslide-directive.js
@@ -1,7 +1,7 @@
 angular.module("pageslide-directive", [])
 
-.directive('pageslide', [
-    function () {
+.directive('pageslide', ['$document',
+    function ($document) {
         var defaults = {};
 
         /* Return directive definition object */
@@ -19,7 +19,8 @@ angular.module("pageslide-directive", [])
                 psSqueeze: "@",
                 psCloak: "@",
                 psPush: "@",
-                psContainer: "@"
+                psContainer: "@",
+                psKeyListener: '@'
             },
             //template: '<div class="pageslide-content" ng-transclude></div>',
             link: function ($scope, el, attrs) {
@@ -39,7 +40,8 @@ angular.module("pageslide-directive", [])
                 param.cloak = $scope.psCloak && $scope.psCloak.toLowerCase() == 'false' ? false : true;
                 param.squeeze = Boolean($scope.psSqueeze) || false;
                 param.push = Boolean($scope.psPush) || false;
-                param.container = $scope.psContainer || false; 
+                param.container = $scope.psContainer || false;
+                param.keyListener = Boolean($scope.psKeyListener) || false;
 
                 // Apply Class
                 el.addClass(param.className);
@@ -74,6 +76,7 @@ angular.module("pageslide-directive", [])
                 slider.style.transitionDuration = param.speed + 's';
                 slider.style.webkitTransitionDuration = param.speed + 's';
                 slider.style.transitionProperty = 'width, height';
+
                 if (param.squeeze) {
                     body.style.position = 'absolute';
                     body.style.transitionDuration = param.speed + 's';
@@ -142,13 +145,18 @@ angular.module("pageslide-directive", [])
                                 slider.style.height = '0px';
                                 if (param.squeeze) body.style.bottom = '0px';
                                 if (param.push) {
-                                    body.style.bottom = '0px'; 
-                                    body.style.top = '0px'; 
+                                    body.style.bottom = '0px';
+                                    body.style.top = '0px';
                                 }
                                 break;
                         }
                     }
                     $scope.psOpen = false;
+
+                    if (param.keyListener) {
+                        $document.off('keydown', keyListener);
+                    }
+
                 }
 
                 /* Open */
@@ -192,12 +200,28 @@ angular.module("pageslide-directive", [])
                             if (param.cloak) content.css('display', 'block');
                         }, (param.speed * 1000));
 
+                        if (param.keyListener) {
+                            $document.on('keydown', keyListener);
+                        }
+
                     }
                 }
 
                 function isFunction(functionToCheck) {
                     var getType = {};
                     return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]';
+                }
+
+                /**
+                 * close the sidebar if the 'esc' key is pressed
+                 */
+                function keyListener(e) {
+                    var ESC_KEY = 27;
+                    var key = e.keyCode || e.which;
+
+                    if (key === ESC_KEY) {
+                        psClose(slider, param);
+                    }
                 }
 
                 /*


### PR DESCRIPTION
added an attribute on the directive that will allow the sidebar to be closed by pressing the 'esc' key. If the 'ps-key-listener' attribute is not set, it defaults to false and the event listener is not attached. If it is set to true the event is attached when the sidebar is opened, the event is also removed when the sidebar is closed. 

