### PR TITLE
Add a main entry pointing to distribution file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "angular-pageslide-directive",
+  "main": "dist/angular-pageslide-directive.js",
   "version": "1.0.3",
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
Allows you to require this package with `require('angular-pageslide-directive')`.

In my case, I am using browserify and do a number of requires in my vendor file.