### PR TITLE
Fixes slider z-index

### DIFF
--- a/src/angular-pageslide-directive.js
+++ b/src/angular-pageslide-directive.js
@@ -80,7 +80,7 @@ angular.module('pageslide-directive', [])
                 body.appendChild(slider);
 
                 /* Slider Style setup */
-                slider.style.zIndex = param.zindex;
+                slider.style['z-index'] = param.zIndex;
                 slider.style.position = param.container !== false ? 'absolute' : 'fixed';
                 slider.style.width = 0;
                 slider.style.height = 0;


### PR DESCRIPTION
Changed style.zIndex to style['z-index'] and set it equal to param.zIndex not param.zindex.