### PR TITLE
Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pane"
   ],
   "version": "1.4.3",
-  "licese": "MIT",
+  "license": "MIT",
   "devDependencies": {
     "grunt": "0.4.5",
     "grunt-contrib-concat": "0.3.0",


### PR DESCRIPTION
There is a typo:

`licese` - should be `license`.